### PR TITLE
Enhance ProtoReader and Add ProtoWriter for protobuf handling

### DIFF
--- a/twister-proto/src/main/java/dev/twister/proto/ProtoWriter.java
+++ b/twister-proto/src/main/java/dev/twister/proto/ProtoWriter.java
@@ -1,0 +1,69 @@
+package dev.twister.proto;
+
+import com.google.protobuf.*;
+import com.google.protobuf.Descriptors.*;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+public class ProtoWriter {
+    public ByteBuffer write(Map<String, Object> object, Descriptor descriptor) {
+        DynamicMessage message = toMessage(object, descriptor);
+        return ByteBuffer.wrap(message.toByteArray());
+    }
+
+    public DynamicMessage toMessage(Map<String, Object> object, Descriptor descriptor) {
+        DynamicMessage.Builder messageBuilder = DynamicMessage.newBuilder(descriptor);
+
+        for (FieldDescriptor fieldDescriptor : descriptor.getFields()) {
+            String fieldName = fieldDescriptor.getName();
+            Object value = object.get(fieldName);
+
+            if (value != null) {
+                if (fieldDescriptor.isRepeated()) {
+                    for (Object element : (Iterable<?>) value) {
+                        messageBuilder.addRepeatedField(fieldDescriptor, toProtobufValue(fieldDescriptor, element));
+                    }
+                } else {
+                    messageBuilder.setField(fieldDescriptor, toProtobufValue(fieldDescriptor, value));
+                }
+            }
+        }
+
+        return messageBuilder.build();
+    }
+
+    private Object toProtobufValue(FieldDescriptor fieldDescriptor, Object value) {
+        switch (fieldDescriptor.getType()) {
+            case INT32:
+            case SINT32:
+            case SFIXED32:
+            case INT64:
+            case SINT64:
+            case SFIXED64:
+            case BOOL:
+            case FLOAT:
+            case STRING:
+            case DOUBLE:
+                return value;
+            case ENUM:
+                EnumDescriptor enumDescriptor = fieldDescriptor.getEnumType();
+                return enumDescriptor.findValueByName((String) value);
+            case FIXED64:
+            case UINT64:
+                BigInteger bigInt = (BigInteger) value;
+                return bigInt.longValue();
+            case BYTES:
+                ByteBuffer byteBuffer = (ByteBuffer) value;
+                return ByteString.copyFrom(byteBuffer);
+            case FIXED32:
+            case UINT32:
+                return ((Long) value).intValue();
+            case MESSAGE:
+                Descriptor messageDescriptor = fieldDescriptor.getMessageType();
+                return toMessage((Map<String, Object>) value, messageDescriptor);
+            default:
+                throw new RuntimeException("Unsupported field type: " + fieldDescriptor.getType());
+        }
+    }
+}

--- a/twister-proto/src/test/java/dev/twister/proto/ProtoReaderTest.java
+++ b/twister-proto/src/test/java/dev/twister/proto/ProtoReaderTest.java
@@ -10,6 +10,7 @@ import com.google.protobuf.DynamicMessage;
 
 import junit.framework.TestCase;
 
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -186,17 +187,17 @@ public class ProtoReaderTest extends TestCase {
         assertEquals(123, resultMap.get("int32_field"));
         assertEquals(1234567890123456789L, resultMap.get("int64_field"));
         assertEquals(456L, resultMap.get("uint32_field"));
-        assertEquals(Long.parseUnsignedLong("9876543210987654321"), resultMap.get("uint64_field"));
+        assertEquals(new BigInteger("9876543210987654321"), resultMap.get("uint64_field"));
         assertEquals(-789, resultMap.get("sint32_field"));
         assertEquals(-1234567890987654321L, resultMap.get("sint64_field"));
         assertEquals(true, resultMap.get("bool_field"));
-        assertEquals(1234567890L, resultMap.get("fixed64_field"));
+        assertEquals(new BigInteger("1234567890"), resultMap.get("fixed64_field"));
         assertEquals(-1234567890L, resultMap.get("sfixed64_field"));
         assertEquals(1234.5678, resultMap.get("double_field"));
-        assertEquals(12345678, resultMap.get("fixed32_field"));
+        assertEquals(12345678L, resultMap.get("fixed32_field"));
         assertEquals(-12345678, resultMap.get("sfixed32_field"));
         assertEquals(12.34f, resultMap.get("float_field"));
-        assertArrayEquals(new byte[]{1, 2, 3, 4, 5}, (byte[]) resultMap.get("bytes_field"));
+        assertEquals(ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}), resultMap.get("bytes_field"));
     }
 
     public void testEnumType() throws Exception {

--- a/twister-proto/src/test/java/dev/twister/proto/ProtoWriterTest.java
+++ b/twister-proto/src/test/java/dev/twister/proto/ProtoWriterTest.java
@@ -1,0 +1,179 @@
+package dev.twister.proto;
+
+import com.github.os72.protobuf.dynamic.DynamicSchema;
+import com.github.os72.protobuf.dynamic.MessageDefinition;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.DynamicMessage;
+import junit.framework.TestCase;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ProtoWriterTest extends TestCase {
+    public void testWrite() throws Exception {
+        // Define a message with all necessary fields
+        MessageDefinition msgDef = MessageDefinition.newBuilder("TestMessage")
+                .addField("required", "int32", "int32_field", 1)
+                .addField("required", "int64", "int64_field", 2)
+                .addField("required", "uint32", "uint32_field", 3)
+                .addField("required", "uint64", "uint64_field", 4)
+                .addField("required", "sint32", "sint32_field", 5)
+                .addField("required", "sint64", "sint64_field", 6)
+                .addField("required", "bool", "bool_field", 7)
+                .addField("required", "string", "enum_field", 8)
+                .addField("required", "fixed64", "fixed64_field", 9)
+                .addField("required", "sfixed64", "sfixed64_field", 10)
+                .addField("required", "double", "double_field", 11)
+                .addField("required", "string", "string_field", 12)
+                .addField("required", "bytes", "bytes_field", 13)
+                .addField("required", "fixed32", "fixed32_field", 14)
+                .addField("required", "sfixed32", "sfixed32_field", 15)
+                .addField("required", "uint32", "big_uint32_field", 16)
+                .addField("required", "uint64", "big_uint64_field", 17)
+                .addField("required", "fixed32", "big_fixed32_field", 18)
+                .addField("required", "fixed64", "big_fixed64_field", 19)
+                .build();
+
+        // Create a dynamic schema
+        DynamicSchema schema = DynamicSchema.newBuilder()
+                .setName("TestSchema.proto")
+                .addMessageDefinition(msgDef)
+                .build();
+
+        // Get descriptor for the dynamic message
+        Descriptor descriptor = schema.getMessageDescriptor("TestMessage");
+
+        // Create a map with the same field names and values
+        Map<String, Object> object = new HashMap<>();
+        object.put("int32_field", 1);
+        object.put("int64_field", 2L);
+        object.put("uint32_field", 3L);
+        object.put("uint64_field", BigInteger.valueOf(4));
+        object.put("sint32_field", 5);
+        object.put("sint64_field", 6L);
+        object.put("bool_field", true);
+        object.put("enum_field", "ENUM_VALUE");
+        object.put("fixed64_field", BigInteger.valueOf(9));
+        object.put("sfixed64_field", 10L);
+        object.put("double_field", 11.0);
+        object.put("string_field", "test string");
+        object.put("bytes_field", ByteBuffer.wrap(new byte[]{1, 2, 3, 4}));
+        object.put("fixed32_field", 14L);
+        object.put("sfixed32_field", 15);
+        object.put("big_uint32_field", 4294967295L);
+        object.put("big_uint64_field", new BigInteger("18446744073709551615"));
+        object.put("big_fixed32_field", 4294967295L);
+        object.put("big_fixed64_field", new BigInteger("18446744073709551615"));
+
+
+        // Create ProtoWriter instance and write the map into a ByteBuffer
+        ProtoWriter writer = new ProtoWriter();
+        ByteBuffer outputBuffer = writer.write(object, descriptor);
+
+        // Parse the ByteBuffer back into a DynamicMessage
+        byte[] outputBytes = new byte[outputBuffer.remaining()];
+        outputBuffer.get(outputBytes);
+        DynamicMessage dynamicMessage = DynamicMessage.parseFrom(descriptor, outputBytes);
+
+        // Assert that the values of each field are as expected
+        assertEquals(1, dynamicMessage.getField(descriptor.findFieldByName("int32_field")));
+        assertEquals(2L, dynamicMessage.getField(descriptor.findFieldByName("int64_field")));
+        assertEquals(3, dynamicMessage.getField(descriptor.findFieldByName("uint32_field")));
+        assertEquals(4L, dynamicMessage.getField(descriptor.findFieldByName("uint64_field")));
+        assertEquals(5, dynamicMessage.getField(descriptor.findFieldByName("sint32_field")));
+        assertEquals(6L, dynamicMessage.getField(descriptor.findFieldByName("sint64_field")));
+        assertEquals(true, dynamicMessage.getField(descriptor.findFieldByName("bool_field")));
+        assertEquals("ENUM_VALUE", dynamicMessage.getField(descriptor.findFieldByName("enum_field")));
+        assertEquals(9L, dynamicMessage.getField(descriptor.findFieldByName("fixed64_field")));
+        assertEquals(10L, dynamicMessage.getField(descriptor.findFieldByName("sfixed64_field")));
+        assertEquals(11.0, dynamicMessage.getField(descriptor.findFieldByName("double_field")));
+        assertEquals("test string", dynamicMessage.getField(descriptor.findFieldByName("string_field")));
+        assertTrue(Arrays.equals(new byte[]{1, 2, 3, 4}, ((ByteString) dynamicMessage.getField(descriptor.findFieldByName("bytes_field"))).toByteArray()));
+        assertEquals(14, dynamicMessage.getField(descriptor.findFieldByName("fixed32_field")));
+        assertEquals(15, dynamicMessage.getField(descriptor.findFieldByName("sfixed32_field")));
+        assertEquals((int) 4294967295L, dynamicMessage.getField(descriptor.findFieldByName("big_uint32_field")));
+        assertEquals(Long.parseUnsignedLong("18446744073709551615"), dynamicMessage.getField(descriptor.findFieldByName("big_uint64_field")));
+        assertEquals((int) 4294967295L, dynamicMessage.getField(descriptor.findFieldByName("big_fixed32_field")));
+        assertEquals(Long.parseUnsignedLong("18446744073709551615"), dynamicMessage.getField(descriptor.findFieldByName("big_fixed64_field")));
+    }
+
+    public void testRepeatedFields() throws Exception {
+        // Define a message with a repeated field
+        MessageDefinition msgDef = MessageDefinition.newBuilder("TestMessage")
+                .addField("repeated", "int32", "int32_field", 1)
+                .build();
+
+        // Create a dynamic schema
+        DynamicSchema schema = DynamicSchema.newBuilder()
+                .setName("TestSchema.proto")
+                .addMessageDefinition(msgDef)
+                .build();
+
+        // Get descriptor for the dynamic message
+        Descriptor descriptor = schema.getMessageDescriptor("TestMessage");
+
+        // Create a map with a repeated field
+        Map<String, Object> object = new HashMap<>();
+        object.put("int32_field", Arrays.asList(1, 2, 3, 4, 5));
+
+        // Create ProtoWriter instance and write the map into a ByteBuffer
+        ByteBuffer outputBuffer = new ProtoWriter().write(object, descriptor);
+
+        // Parse the ByteBuffer back into a DynamicMessage
+        byte[] outputBytes = new byte[outputBuffer.remaining()];
+        outputBuffer.get(outputBytes);
+        DynamicMessage dynamicMessage = DynamicMessage.parseFrom(descriptor, outputBytes);
+
+        // Assert that the values of the repeated field are as expected
+        @SuppressWarnings("unchecked")
+        List<Integer> actualValues = (List<Integer>) dynamicMessage.getField(descriptor.findFieldByName("int32_field"));
+        List<Integer> expectedValues = Arrays.asList(1, 2, 3, 4, 5);
+        assertEquals(expectedValues, actualValues);
+    }
+
+    public void testNestedMessage() throws Exception {
+        // Define a nested message
+        MessageDefinition nestedMsgDef = MessageDefinition.newBuilder("NestedMessage")
+                .addField("required", "int32", "nested_int32_field", 1)
+                .build();
+
+        // Define a message with a nested message field
+        MessageDefinition msgDef = MessageDefinition.newBuilder("TestMessage")
+                .addField("required", "NestedMessage", "nested_message_field", 1)
+                .build();
+
+        // Create a dynamic schema
+        DynamicSchema schema = DynamicSchema.newBuilder()
+                .setName("TestSchema.proto")
+                .addMessageDefinition(nestedMsgDef)
+                .addMessageDefinition(msgDef)
+                .build();
+
+        // Get descriptor for the dynamic message
+        Descriptor descriptor = schema.getMessageDescriptor("TestMessage");
+
+        // Create a map with a nested map
+        Map<String, Object> nestedObject = new HashMap<>();
+        nestedObject.put("nested_int32_field", 42);
+
+        Map<String, Object> object = new HashMap<>();
+        object.put("nested_message_field", nestedObject);
+
+        // Create ProtoWriter instance and write the map into a ByteBuffer
+        ByteBuffer outputBuffer = new ProtoWriter().write(object, descriptor);
+
+        // Parse the ByteBuffer back into a DynamicMessage
+        byte[] outputBytes = new byte[outputBuffer.remaining()];
+        outputBuffer.get(outputBytes);
+        DynamicMessage dynamicMessage = DynamicMessage.parseFrom(descriptor, outputBytes);
+
+        // Assert that the values of the nested message field are as expected
+        DynamicMessage nestedMessage = (DynamicMessage) dynamicMessage.getField(descriptor.findFieldByName("nested_message_field"));
+        assertEquals(42, nestedMessage.getField(nestedMessage.getDescriptorForType().findFieldByName("nested_int32_field")));
+    }
+}


### PR DESCRIPTION
This commit includes two significant changes:

1. Enhancement to the ProtoReader:
   - Added handling for `UINT32`, `FIXED32`, `UINT64`, and `FIXED64` types, converting them to `long` and `BigInteger` respectively.
   - Implemented reading of `BYTES` type, which is converted to a `ByteBuffer`.
   - Adjusted the handling of `Fixed64`, `SFixed64`, `Double`, `Fixed32`, `SFixed32`, and `Float` to use a switch statement for more clarity.

2. Added ProtoWriter:
   - This new class allows conversion of a `Java Map<String, Object>` into a protobuf message using the provided protobuf descriptor.
   - Handles `MESSAGE` types by treating them as nested `Java Map<String, Object>` and recursing into them. Coercion looks like this:

```
int32: int
int64: long
uint32: long
uint64: BigInteger
sint32: int
sint64: long
bool: boolean
enum: string
fixed64: BigInteger
sfixed64: long
double: Double
string: String
bytes: ByteBuffer
fixed32: long
sfixed32: int
float: Float
```