### PR TITLE
Add Documentation to Avro and Proto Classes

### DIFF
--- a/twister-avro/src/main/java/dev/twister/avro/AvroReader.java
+++ b/twister-avro/src/main/java/dev/twister/avro/AvroReader.java
@@ -11,12 +11,32 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * A utility class to read Avro-encoded data into Java Map objects.
+ */
 public class AvroReader {
+
+    /**
+     * Reads Avro-encoded data from a ByteBuffer using a provided schema.
+     *
+     * @param inputBuffer The ByteBuffer containing the Avro-encoded data.
+     * @param schema The Avro schema that describes the data structure.
+     * @return A Map representing the Avro data.
+     * @throws IOException If there is a problem reading from the ByteBuffer.
+     */
     public Map<String, Object> read(ByteBuffer inputBuffer, Schema schema) throws IOException {
         BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(inputBuffer.array(), null);
         return (Map<String, Object>) readBasedOnSchema(decoder, schema);
     }
 
+    /**
+     * Reads Avro-encoded data from a BinaryDecoder based on a provided schema.
+     *
+     * @param decoder The BinaryDecoder to read data from.
+     * @param schema The Avro schema that describes the data structure.
+     * @return An Object representing the Avro data.
+     * @throws IOException If there is a problem reading from the BinaryDecoder.
+     */
     private Object readBasedOnSchema(BinaryDecoder decoder, Schema schema) throws IOException {
         switch (schema.getType()) {
             case RECORD:
@@ -62,6 +82,15 @@ public class AvroReader {
         }
     }
 
+    /**
+     * Reads a primitive value from a BinaryDecoder based on a provided schema type.
+     *
+     * @param decoder The BinaryDecoder to read data from.
+     * @param type The Avro schema type of the primitive value.
+     * @return An Object representing the Avro primitive value.
+     * @throws IOException If there is a problem reading from the BinaryDecoder.
+     * @throws IllegalArgumentException If the schema type is unsupported.
+     */
     private Object readPrimitive(BinaryDecoder decoder, Schema.Type type) throws IOException {
         switch (type) {
             case BOOLEAN:

--- a/twister-avro/src/main/java/dev/twister/avro/AvroSchemaInferrer.java
+++ b/twister-avro/src/main/java/dev/twister/avro/AvroSchemaInferrer.java
@@ -6,21 +6,53 @@ import org.apache.avro.SchemaBuilder;
 import java.nio.ByteBuffer;
 import java.util.*;
 
+/**
+ * A utility class to infer Avro schema from Java objects.
+ */
 public class AvroSchemaInferrer {
+
+    /**
+     * Flag indicating whether maps should be treated as records during Avro schema inference.
+     * Default value is {@code true}.
+     */
     private final boolean mapAsRecord;
 
+    /**
+     * Creates an AvroSchemaInferrer with the default behavior of treating maps as records.
+     */
     public AvroSchemaInferrer() {
         this(true);
     }
 
+    /**
+     * Creates an AvroSchemaInferrer.
+     *
+     * @param mapAsRecord A flag to indicate whether maps should be treated as records.
+     */
     public AvroSchemaInferrer(boolean mapAsRecord) {
         this.mapAsRecord = mapAsRecord;
     }
 
+    /**
+     * Infers an Avro schema from a given Java Map and a record name.
+     *
+     * @param object The Java Map to infer the schema from.
+     * @param recordName The name of the record.
+     * @return The inferred Avro schema.
+     */
     public Schema schema(Map<String, Object> object, String recordName) {
         return getSchemaBasedOnObjectType(object, recordName, null);
     }
 
+    /**
+     * Infers an Avro schema based on the type of the given object.
+     *
+     * @param value The object to infer the schema from.
+     * @param fieldName The name of the field for the object.
+     * @param parentName The name of the parent field, or null if there's no parent.
+     * @return The inferred Avro schema.
+     * @throws IllegalArgumentException If the object's type is unsupported or if the object is an empty array.
+     */
     private Schema getSchemaBasedOnObjectType(Object value, String fieldName, String parentName) {
         Schema schema;
         String finalRecordName = (parentName != null) ? parentName + "_" + fieldName : fieldName;
@@ -68,6 +100,13 @@ public class AvroSchemaInferrer {
         return schema;
     }
 
+    /**
+     * Handles the inference of an Avro schema for a map treated as a record.
+     *
+     * @param sortedMap The sorted map to infer the schema from.
+     * @param finalRecordName The final name of the record.
+     * @return The inferred Avro schema.
+     */
     private Schema handleMapAsRecord(Map<String, Object> sortedMap, String finalRecordName) {
         SchemaBuilder.FieldAssembler<Schema> fields = SchemaBuilder.record(finalRecordName).fields();
 
@@ -79,6 +118,13 @@ public class AvroSchemaInferrer {
         return fields.endRecord();
     }
 
+    /**
+     * Handles the inference of an Avro schema for a map treated as a map.
+     *
+     * @param sortedMap The sorted map to infer the schema from.
+     * @param finalRecordName The final name of the record.
+     * @return The inferred Avro schema.
+     */
     private Schema handleMapAsMap(Map<String, Object> sortedMap, String finalRecordName) {
         Set<Schema> fieldSchemas = new HashSet<>();
         Set<String> schemaTypes = new HashSet<>();
@@ -100,6 +146,12 @@ public class AvroSchemaInferrer {
         return SchemaBuilder.map().values(union.endUnion());
     }
 
+    /**
+     * Returns a nullable version of the given schema.
+     *
+     * @param schema The schema to make nullable.
+     * @return The nullable schema.
+     */
     private Schema nullableSchema(Schema schema) {
         if (schema.getType() != Schema.Type.NULL) {
             return SchemaBuilder.unionOf().nullType().and().type(schema).endUnion();

--- a/twister-avro/src/main/java/dev/twister/avro/AvroWriter.java
+++ b/twister-avro/src/main/java/dev/twister/avro/AvroWriter.java
@@ -12,7 +12,14 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * This class provides functionality to write Avro data based on the provided Avro schema and data.
+ */
 public class AvroWriter {
+
+    /**
+     * This class provides functionality to write Avro data based on a provided Avro schema and map data.
+     */
     public class MapDatumWriter implements DatumWriter<Map<String, Object>> {
         private Schema schema;
 
@@ -25,6 +32,14 @@ public class AvroWriter {
             this.schema = schema;
         }
 
+        /**
+         * Writes an object to the encoder output based on the provided Avro schema.
+         *
+         * @param value The object to be written.
+         * @param schema The Avro schema to use for writing.
+         * @param out The encoder output to write to.
+         * @throws IOException If an error occurs during writing.
+         */
         private void writeObject(Object value, Schema schema, Encoder out) throws IOException {
             switch (schema.getType()) {
                 case BOOLEAN:
@@ -114,6 +129,13 @@ public class AvroWriter {
             }
         }
 
+        /**
+         * Returns the expected Java class for the provided Avro schema.
+         *
+         * @param schema The Avro schema to get the expected class for.
+         * @return The expected Java class for the provided Avro schema.
+         * @throws UnsupportedOperationException If the schema type is unsupported.
+         */
         private Class<?> getExpectedClass(Schema schema) {
             switch (schema.getType()) {
                 case BOOLEAN: return Boolean.class;
@@ -133,6 +155,14 @@ public class AvroWriter {
             }
         }
 
+        /**
+         * Returns the index of the matching schema in the list of union schemas.
+         *
+         * @param value The value to match the schema with.
+         * @param unionSchemas The list of union schemas.
+         * @return The index of the matching schema in the list of union schemas.
+         * @throws IOException If no matching schema is found.
+         */
         private int getMatchingSchemaIndex(Object value, List<Schema> unionSchemas) throws IOException {
             for (int i = 0; i < unionSchemas.size(); i++) {
                 Schema unionSchema = unionSchemas.get(i);
@@ -148,6 +178,14 @@ public class AvroWriter {
         }
     }
 
+    /**
+     * Writes the given object to a ByteBuffer based on the inferred Avro schema.
+     *
+     * @param object The object to be written.
+     * @param recordName The name of the Avro record.
+     * @return A ByteBuffer containing the written Avro data.
+     * @throws IOException If an error occurs during writing.
+     */
     public ByteBuffer write(Map<String, Object> object, String recordName) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(outputStream, null);
@@ -157,6 +195,14 @@ public class AvroWriter {
         return ByteBuffer.wrap(outputStream.toByteArray());
     }
 
+    /**
+     * Writes the given object to a ByteBuffer based on the provided Avro schema.
+     *
+     * @param object The object to be written.
+     * @param schema The Avro schema to use for writing.
+     * @return A ByteBuffer containing the written Avro data.
+     * @throws IOException If an error occurs during writing.
+     */
     public ByteBuffer write(Map<String, Object> object, Schema schema) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(outputStream, null);

--- a/twister-proto/src/main/java/dev/twister/proto/ProtoDescriptorInferrer.java
+++ b/twister-proto/src/main/java/dev/twister/proto/ProtoDescriptorInferrer.java
@@ -8,7 +8,19 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * A utility class to infer a Protocol Buffers message descriptor from a Map of objects.
+ */
 public class ProtoDescriptorInferrer {
+
+    /**
+     * Infers a Protocol Buffers message descriptor from a Map of objects and assigns it a message name.
+     *
+     * @param object The Map of objects to infer the descriptor from.
+     * @param messageName The name to assign to the message in the descriptor.
+     * @return The inferred Protocol Buffers message descriptor.
+     * @throws RuntimeException If there is an error validating the inferred descriptor.
+     */
     public Descriptors.Descriptor descriptor(Map<String, Object> object, String messageName) {
         DescriptorProtos.FileDescriptorProto.Builder fileDescriptorBuilder = DescriptorProtos.FileDescriptorProto.newBuilder();
         DescriptorProtos.DescriptorProto.Builder messageBuilder = DescriptorProtos.DescriptorProto.newBuilder();
@@ -57,6 +69,13 @@ public class ProtoDescriptorInferrer {
         }
     }
 
+    /**
+     * Infers the Protocol Buffers field type from an Object.
+     *
+     * @param value The object to infer the field type from.
+     * @return The inferred Protocol Buffers field type.
+     * @throws IllegalArgumentException If the object type is unsupported.
+     */
     private Descriptors.FieldDescriptor.Type inferFieldType(Object value) {
         if (value instanceof Integer) {
             return Descriptors.FieldDescriptor.Type.INT32;

--- a/twister-proto/src/main/java/dev/twister/proto/ProtoReader.java
+++ b/twister-proto/src/main/java/dev/twister/proto/ProtoReader.java
@@ -14,8 +14,20 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * A utility class for reading a Protocol Buffers message from a ByteBuffer and converting it into a Map.
+ */
 public class ProtoReader {
 
+    /**
+     * Reads a Protocol Buffers message from a ByteBuffer and converts it into a Map.
+     *
+     * @param inputBuffer The ByteBuffer containing the Protocol Buffers message.
+     * @param descriptor The Descriptor of the Protocol Buffers message.
+     * @return A Map representing the Protocol Buffers message.
+     * @throws IllegalArgumentException If an unknown field number or enum value is encountered.
+     * @throws UnsupportedOperationException If an unsupported wire type or field type is encountered.
+     */
     public static Map<String, Object> read(ByteBuffer inputBuffer, Descriptor descriptor) {
         Map<String, Object> resultMap = new HashMap<>();
 
@@ -163,6 +175,15 @@ public class ProtoReader {
         return resultMap;
     }
 
+    /**
+     * Adds a field value to the result Map, handling repeated and oneof fields.
+     *
+     * @param resultMap The result Map.
+     * @param fieldName The name of the field.
+     * @param value The value of the field.
+     * @param isRepeated Whether the field is a repeated field.
+     * @param isOneof Whether the field is part of a oneof.
+     */
     private static void addToResultMap(Map<String, Object> resultMap, String fieldName, Object value, boolean isRepeated, boolean isOneof) {
         if (isOneof || !isRepeated) {
             resultMap.put(fieldName, value);
@@ -179,6 +200,12 @@ public class ProtoReader {
         }
     }
 
+    /**
+     * Reads a varint from a ByteBuffer and converts it to a long.
+     *
+     * @param byteBuffer The ByteBuffer to read from.
+     * @return The varint as a long.
+     */
     private static long readVarint(ByteBuffer byteBuffer) {
         long result = 0;
         int shift = 0;
@@ -193,10 +220,22 @@ public class ProtoReader {
         return result;
     }
 
+    /**
+     * Decodes a ZigZag-encoded 32-bit integer.
+     *
+     * @param n The ZigZag-encoded integer to decode.
+     * @return The decoded integer.
+     */
     private static int decodeZigZag32(int n) {
         return (n >>> 1) ^ -(n & 1);
     }
 
+    /**
+     * Decodes a ZigZag-encoded 64-bit integer.
+     *
+     * @param n The ZigZag-encoded integer to decode.
+     * @return The decoded integer.
+     */
     private static long decodeZigZag64(long n) {
         return (n >>> 1) ^ -(n & 1);
     }

--- a/twister-proto/src/main/java/dev/twister/proto/ProtoWriter.java
+++ b/twister-proto/src/main/java/dev/twister/proto/ProtoWriter.java
@@ -6,12 +6,32 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
+/**
+ * A utility class for converting a Map into a Protocol Buffers message and writing it to a ByteBuffer.
+ */
 public class ProtoWriter {
+
+    /**
+     * Converts a Map into a Protocol Buffers message and writes it to a ByteBuffer.
+     *
+     * @param object The Map representing the Protocol Buffers message.
+     * @param descriptor The Descriptor of the Protocol Buffers message.
+     * @return A ByteBuffer containing the Protocol Buffers message.
+     * @throws RuntimeException If an unsupported field type is encountered.
+     */
     public ByteBuffer write(Map<String, Object> object, Descriptor descriptor) {
         DynamicMessage message = toMessage(object, descriptor);
         return ByteBuffer.wrap(message.toByteArray());
     }
 
+    /**
+     * Converts a Map into a DynamicMessage representing a Protocol Buffers message.
+     *
+     * @param object The Map representing the Protocol Buffers message.
+     * @param descriptor The Descriptor of the Protocol Buffers message.
+     * @return A DynamicMessage representing the Protocol Buffers message.
+     * @throws RuntimeException If an unsupported field type is encountered.
+     */
     public DynamicMessage toMessage(Map<String, Object> object, Descriptor descriptor) {
         DynamicMessage.Builder messageBuilder = DynamicMessage.newBuilder(descriptor);
 
@@ -33,6 +53,14 @@ public class ProtoWriter {
         return messageBuilder.build();
     }
 
+    /**
+     * Converts a Java object into a Protocol Buffers value according to the provided field descriptor.
+     *
+     * @param fieldDescriptor The descriptor of the field.
+     * @param value The Java object to convert.
+     * @return The converted Protocol Buffers value.
+     * @throws RuntimeException If an unsupported field type is encountered.
+     */
     private Object toProtobufValue(FieldDescriptor fieldDescriptor, Object value) {
         switch (fieldDescriptor.getType()) {
             case INT32:


### PR DESCRIPTION
In this commit, we've added JavaDoc comments to several classes in the `twister-avro` and `twister-proto` packages. This provides a clearer understanding of the purpose and use of each class and method.

In the `twister-avro` package, the `AvroReader`, `AvroSchemaInferrer`, and `AvroWriter` classes were updated.

In the `twister-proto` package, we enhanced `ProtoDescriptorInferrer`, `ProtoReader`, and `ProtoWriter` with detailed comments.

This commit will greatly improve code readability and maintainability by providing necessary context to developers working with these classes.