### PR TITLE
Add `write` method overload in ProtoWriter and corresponding test

### DIFF
--- a/twister-proto/src/main/java/dev/twister/proto/ProtoWriter.java
+++ b/twister-proto/src/main/java/dev/twister/proto/ProtoWriter.java
@@ -12,6 +12,18 @@ import java.util.Map;
 public class ProtoWriter {
 
     /**
+     * Writes a given object map into a ByteBuffer using the specified message name.
+     * It uses a new instance of ProtoDescriptorInferrer to generate the descriptor.
+     *
+     * @param object The Map representing the Protocol Buffers message.
+     * @param messageName The name of the Protocol Buffers message.
+     * @return A ByteBuffer containing the Protocol Buffers message.
+     */
+    public ByteBuffer write(Map<String, Object> object, String messageName) {
+        return write(object, new ProtoDescriptorInferrer().descriptor(object, messageName));
+    }
+
+    /**
      * Converts a Map into a Protocol Buffers message and writes it to a ByteBuffer.
      *
      * @param object The Map representing the Protocol Buffers message.


### PR DESCRIPTION
This commit adds a new overload for the `write` method in the `ProtoWriter` class, which now accepts a message name string and infers the descriptor using a new instance of `ProtoDescriptorInferrer`. A test case `testWriteWithInferredDescriptor` has been added to the `ProtoWriterTest` class to ensure this new functionality is correctly working.

Changes include:
* New `write` method overload in `ProtoWriter` with Javadoc documentation.
* New test case `testWriteWithInferredDescriptor` in `ProtoWriterTest`.
* Minor import optimization in `ProtoWriterTest`.