### PR TITLE
Rename `schema` to `infer` in Avro and Proto Inferrer classes

### DIFF
--- a/twister-avro/src/main/java/dev/twister/avro/AvroSchemaInferrer.java
+++ b/twister-avro/src/main/java/dev/twister/avro/AvroSchemaInferrer.java
@@ -40,7 +40,7 @@ public class AvroSchemaInferrer {
      * @param recordName The name of the record.
      * @return The inferred Avro schema.
      */
-    public Schema schema(Map<String, Object> object, String recordName) {
+    public Schema infer(Map<String, Object> object, String recordName) {
         return getSchemaBasedOnObjectType(object, recordName, null);
     }
 

--- a/twister-avro/src/main/java/dev/twister/avro/AvroWriter.java
+++ b/twister-avro/src/main/java/dev/twister/avro/AvroWriter.java
@@ -189,7 +189,7 @@ public class AvroWriter {
     public ByteBuffer write(Map<String, Object> object, String recordName) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(outputStream, null);
-        MapDatumWriter writer = new MapDatumWriter(new AvroSchemaInferrer().schema(object, recordName));
+        MapDatumWriter writer = new MapDatumWriter(new AvroSchemaInferrer().infer(object, recordName));
         writer.write(object, encoder);
         encoder.flush();
         return ByteBuffer.wrap(outputStream.toByteArray());

--- a/twister-avro/src/test/java/dev/twister/avro/AvroSchemaInferrerTest.java
+++ b/twister-avro/src/test/java/dev/twister/avro/AvroSchemaInferrerTest.java
@@ -19,7 +19,7 @@ public class AvroSchemaInferrerTest extends TestCase {
         testMap.put("doubleField", 2.718281828);
         testMap.put("nullField", null);
 
-        Schema inferredSchema = new AvroSchemaInferrer().schema(testMap, "TestSchema");
+        Schema inferredSchema = new AvroSchemaInferrer().infer(testMap, "TestSchema");
 
         // Define expected schema with fields added in alphabetical order
         Schema expectedSchema = SchemaBuilder.record("TestSchema").fields()
@@ -40,7 +40,7 @@ public class AvroSchemaInferrerTest extends TestCase {
         AvroSchemaInferrer inferrer = new AvroSchemaInferrer();
         Map<String, Object> map = new HashMap<>();
         map.put("array", Arrays.asList(1, 2, 3));
-        Schema schema = inferrer.schema(map, "TestArray");
+        Schema schema = inferrer.infer(map, "TestArray");
         String expectedSchema = "{\"type\":\"record\",\"name\":\"TestArray\",\"fields\":[{\"name\":\"array\",\"type\":[\"null\",{\"type\":\"array\",\"items\":[\"null\",\"int\"]}]}]}";
         assertEquals(expectedSchema, schema.toString());
     }
@@ -51,7 +51,7 @@ public class AvroSchemaInferrerTest extends TestCase {
         Map<String, Object> subMap = new HashMap<>();
         subMap.put("subField", "subValue");
         map.put("field", subMap);
-        Schema schema = inferrer.schema(map, "TestComplexMap");
+        Schema schema = inferrer.infer(map, "TestComplexMap");
         String expectedSchema = "{\"type\":\"record\",\"name\":\"TestComplexMap\",\"fields\":[{\"name\":\"field\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"TestComplexMap_field\",\"fields\":[{\"name\":\"subField\",\"type\":[\"null\",\"string\"]}]}]}]}";
         assertEquals(expectedSchema, schema.toString());
     }
@@ -67,7 +67,7 @@ public class AvroSchemaInferrerTest extends TestCase {
         AvroSchemaInferrer inferrer = new AvroSchemaInferrer(false);
 
         // Infer the Avro schema for the map
-        Schema schema = inferrer.schema(map, "TestRecord");
+        Schema schema = inferrer.infer(map, "TestRecord");
 
         // Check that the resulting schema is a map schema with a union value type
         assertEquals(Schema.Type.MAP, schema.getType());

--- a/twister-proto/src/main/java/dev/twister/proto/ProtoDescriptorInferrer.java
+++ b/twister-proto/src/main/java/dev/twister/proto/ProtoDescriptorInferrer.java
@@ -21,7 +21,7 @@ public class ProtoDescriptorInferrer {
      * @return The inferred Protocol Buffers message descriptor.
      * @throws RuntimeException If there is an error validating the inferred descriptor.
      */
-    public Descriptors.Descriptor descriptor(Map<String, Object> object, String messageName) {
+    public Descriptors.Descriptor infer(Map<String, Object> object, String messageName) {
         DescriptorProtos.FileDescriptorProto.Builder fileDescriptorBuilder = DescriptorProtos.FileDescriptorProto.newBuilder();
         DescriptorProtos.DescriptorProto.Builder messageBuilder = DescriptorProtos.DescriptorProto.newBuilder();
         int fieldNumber = 1;
@@ -44,7 +44,7 @@ public class ProtoDescriptorInferrer {
                 Descriptors.FieldDescriptor.Type fieldType = inferFieldType(((List<?>) fieldValue).get(0));
                 fieldBuilder.setType(fieldType.toProto());
             } else if (fieldValue instanceof Map) {
-                DescriptorProtos.DescriptorProto nestedMessage = descriptor((Map<String, Object>) fieldValue, messageName + "_" + fieldName).toProto();
+                DescriptorProtos.DescriptorProto nestedMessage = infer((Map<String, Object>) fieldValue, messageName + "_" + fieldName).toProto();
                 messageBuilder.addNestedType(nestedMessage);
                 fieldBuilder.setTypeName(nestedMessage.getName());
                 fieldBuilder.setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL);

--- a/twister-proto/src/main/java/dev/twister/proto/ProtoWriter.java
+++ b/twister-proto/src/main/java/dev/twister/proto/ProtoWriter.java
@@ -20,7 +20,7 @@ public class ProtoWriter {
      * @return A ByteBuffer containing the Protocol Buffers message.
      */
     public ByteBuffer write(Map<String, Object> object, String messageName) {
-        return write(object, new ProtoDescriptorInferrer().descriptor(object, messageName));
+        return write(object, new ProtoDescriptorInferrer().infer(object, messageName));
     }
 
     /**

--- a/twister-proto/src/test/java/dev/twister/proto/ProtoDescriptorInferrerTest.java
+++ b/twister-proto/src/test/java/dev/twister/proto/ProtoDescriptorInferrerTest.java
@@ -25,7 +25,7 @@ public class ProtoDescriptorInferrerTest extends TestCase {
         object.put("fieldFloat", Float.valueOf(32.0f));
         object.put("fieldBigInt", BigInteger.valueOf(Long.MAX_VALUE));
 
-        Descriptors.Descriptor descriptor = new ProtoDescriptorInferrer().descriptor(object, "TestMessage");
+        Descriptors.Descriptor descriptor = new ProtoDescriptorInferrer().infer(object, "TestMessage");
 
         // Create expected schema using DynamicSchema
         DynamicSchema.Builder schemaBuilder = DynamicSchema.newBuilder();
@@ -55,7 +55,7 @@ public class ProtoDescriptorInferrerTest extends TestCase {
         List<Integer> intList = Arrays.asList(32, 33, 34);
         object.put("fieldRepeated", intList);
 
-        Descriptors.Descriptor descriptor = new ProtoDescriptorInferrer().descriptor(object, "TestMessage");
+        Descriptors.Descriptor descriptor = new ProtoDescriptorInferrer().infer(object, "TestMessage");
 
         // Create expected schema using DynamicSchema
         DynamicSchema.Builder schemaBuilder = DynamicSchema.newBuilder();
@@ -87,7 +87,7 @@ public class ProtoDescriptorInferrerTest extends TestCase {
         object.put("fieldStr", "string");
         object.put("nestedMessage", nestedObject);
 
-        Descriptors.Descriptor descriptor = inferrer.descriptor(object, "TestMessage");
+        Descriptors.Descriptor descriptor = inferrer.infer(object, "TestMessage");
 
         // Create expected schema using DynamicSchema
         DynamicSchema.Builder schemaBuilder = DynamicSchema.newBuilder();


### PR DESCRIPTION
This commit renames the `schema` method to `infer` in both `AvroSchemaInferrer` and `ProtoDescriptorInferrer` classes. The corresponding changes are also made in `AvroWriter`, `ProtoWriter`, and their respective test classes.

Changes include:
* Renaming `schema` to `infer` in `AvroSchemaInferrer` and updating the corresponding call in `AvroWriter`.
* Renaming `schema` to `infer` in `ProtoDescriptorInferrer` and updating the corresponding call in `ProtoWriter`.
* Updating `AvroSchemaInferrerTest` and `ProtoDescriptorInferrerTest` to reflect these changes.