### PR TITLE
Add AvroWrapper class to wrap Avro IndexedRecords in Map representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Twister converts [Avro](https://avro.apache.org/) and [Protobuf](https://protobu
 Twister does some trippy stuff:
 
 * Avro Record bytes ↔️ Map POJOs
+* Avro Record objects ➡️ Map wrapper
 * Protobuf Message bytes ↔️ Map POJOs
 * Map POJOs ➡️ Avro Schema
 * Map POJOs ➡️ Protobuf Descriptor
@@ -40,6 +41,12 @@ Decode Avro bytes directly into POJO objects, bypassing Avro record classes:
 ```java
 Map<String, Object> object = new AvroReader().read(bytes, schema);
 ```
+Wrap an existing Avro record in a POJO map:
+
+```java
+Map<String, Object> wrapped = new AvroWrapper().wrap(record);
+```
+
 Encode POJO objects directly into Avro bytes:
 
 ```java
@@ -73,7 +80,6 @@ Despite its simplicity and flexibility, Twister attempts to maintain decent perf
 * Avro default support
 * Avro logical type support
 * Protobuf WKT support
-* Avro Record ➡️ Map wrapper
 * Protobuf Message ➡️ Map wrapper
 * .proto ➡️ Protobuf Descriptor converter
 * JDBC row ➡️ Map wrapper

--- a/twister-avro/src/main/java/dev/twister/avro/AvroWrapper.java
+++ b/twister-avro/src/main/java/dev/twister/avro/AvroWrapper.java
@@ -1,0 +1,202 @@
+package dev.twister.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.IndexedRecord;
+
+import java.nio.ByteBuffer;
+import java.util.*;
+
+/**
+ * This class provides functionality to wrap Avro IndexedRecord objects
+ * into a Map representation for easier data manipulation.
+ */
+public class AvroWrapper {
+
+    /**
+     * Wraps the given IndexedRecord into a Map.
+     *
+     * @param record the IndexedRecord to be wrapped
+     * @return a Map representing the IndexedRecord
+     */
+    public Map<String, Object> wrap(IndexedRecord record) {
+        return new Facade(record);
+    }
+
+    /**
+     * This method coerces the value into the correct Java type based on the Avro schema.
+     * It supports Avro primitives, as well as complex types like records (which it wraps
+     * with Facade), arrays (which it wraps with FacadeList), and maps (which it wraps with FacadeMap).
+     *
+     * @param schema the Avro schema of the value
+     * @param value the value to be coerced
+     * @return the coerced value, or throws IllegalArgumentException if the Avro type is unsupported
+     */
+    private Object coerceType(Schema schema, Object value) {
+        switch (schema.getType()) {
+            case RECORD:
+                return new Facade((IndexedRecord) value);
+            case ENUM:
+                return value.toString();
+            case UNION:
+                return coerceType(schema.getTypes().get(0), value);
+            case FIXED:
+                return ByteBuffer.wrap(((GenericFixed) value).bytes());
+            case ARRAY:
+                return new FacadeList(schema.getElementType(), (List<?>) value);
+            case MAP:
+                return new FacadeMap(schema.getValueType(), (Map<String, Object>) value);
+            case BOOLEAN:
+            case INT:
+            case LONG:
+            case FLOAT:
+            case DOUBLE:
+            case STRING:
+                return value;
+            case BYTES:
+                if (value instanceof ByteBuffer) {
+                    return value;
+                } else if (value instanceof byte[]) {
+                    return ByteBuffer.wrap((byte[]) value);
+                } else {
+                    throw new IllegalArgumentException("Unsupported type for BYTES: " + value.getClass());
+                }
+            case NULL:
+                return null;
+            default:
+                throw new IllegalArgumentException("Unsupported type: " + schema.getType());
+        }
+    }
+
+    /**
+     * Facade is a private class that provides a Map view of a given IndexedRecord.
+     * This facilitates easier manipulation of the IndexedRecord's data.
+     * The map's keys are the field names in the IndexedRecord, and the values are the field values,
+     * which are coerced to appropriate Java types using the coerceType method.
+     */
+    private class Facade extends AbstractMap<String, Object> {
+
+        private final IndexedRecord record;
+
+        Facade(IndexedRecord record) {
+            this.record = record;
+        }
+
+        @Override
+        public Set<Entry<String, Object>> entrySet() {
+            return new AbstractSet<>() {
+
+                @Override
+                public Iterator<Entry<String, Object>> iterator() {
+                    return new Iterator<>() {
+                        private final Iterator<Schema.Field> iterator = record.getSchema().getFields().iterator();
+
+                        @Override
+                        public boolean hasNext() {
+                            return iterator.hasNext();
+                        }
+
+                        @Override
+                        public Entry<String, Object> next() {
+                            Schema.Field field = iterator.next();
+                            return new SimpleImmutableEntry<>(field.name(), coerceType(field.schema(), record.get(field.pos())));
+                        }
+                    };
+                }
+
+                @Override
+                public int size() {
+                    return record.getSchema().getFields().size();
+                }
+            };
+        }
+    }
+
+    /**
+     * FacadeList is a private class that provides a List view of a given Avro array.
+     * This facilitates easier manipulation of the array's data.
+     * The list's elements are the array items, which are coerced to appropriate Java types
+     * using the coerceType method.
+     */
+    private class FacadeList extends AbstractList<Object> {
+
+        private final Schema elementSchema;
+        private final List<?> list;
+
+        /**
+         * Creates a new FacadeList object that provides a List view of the given Avro array.
+         * The List's elements will be the array items, coerced to appropriate Java types
+         * using the coerceType method.
+         *
+         * @param elementSchema the Avro schema of the elements in the array
+         * @param list the actual list of elements, which will be coerced to appropriate Java types
+         */
+        FacadeList(Schema elementSchema, List<?> list) {
+            this.elementSchema = elementSchema;
+            this.list = list;
+        }
+
+        @Override
+        public Object get(int index) {
+            return coerceType(elementSchema, list.get(index));
+        }
+
+        @Override
+        public int size() {
+            return list.size();
+        }
+    }
+
+    /**
+     * FacadeMap is a private class that provides a Map view of a given Avro map.
+     * This facilitates easier manipulation of the map's data.
+     * The map's keys are the Avro map's keys, and the values are the map values,
+     * which are coerced to appropriate Java types using the coerceType method.
+     */
+    private class FacadeMap extends AbstractMap<String, Object> {
+
+        private final Schema valueSchema;
+        private final Map<String, Object> map;
+
+        /**
+         * Creates a new FacadeMap object that provides a Map view of the given Avro map.
+         * The Map's values will be the map values, coerced to appropriate Java types
+         * using the coerceType method.
+         *
+         * @param valueSchema the Avro schema of the values in the map
+         * @param map the actual map of keys to values, which will be coerced to appropriate Java types
+         */
+        FacadeMap(Schema valueSchema, Map<String, Object> map) {
+            this.valueSchema = valueSchema;
+            this.map = map;
+        }
+
+        @Override
+        public Set<Entry<String, Object>> entrySet() {
+            return new AbstractSet<>() {
+                @Override
+                public Iterator<Entry<String, Object>> iterator() {
+                    return new Iterator<>() {
+                        private final Iterator<Entry<String, Object>> iterator = map.entrySet().iterator();
+
+                        @Override
+                        public boolean hasNext() {
+                            return iterator.hasNext();
+                        }
+
+                        @Override
+                        public Entry<String, Object> next() {
+                            Entry<String, Object> entry = iterator.next();
+                            return new SimpleImmutableEntry<>(entry.getKey(), coerceType(valueSchema, entry.getValue()));
+                        }
+                    };
+                }
+
+                @Override
+                public int size() {
+                    return map.size();
+                }
+            };
+        }
+    }
+}

--- a/twister-avro/src/test/java/dev/twister/avro/AvroWrapperTest.java
+++ b/twister-avro/src/test/java/dev/twister/avro/AvroWrapperTest.java
@@ -1,0 +1,197 @@
+package dev.twister.avro;
+
+import junit.framework.TestCase;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+
+import java.nio.ByteBuffer;
+import java.util.*;
+
+public class AvroWrapperTest extends TestCase {
+    public void testWrapPrimitives() {
+        Schema schema = Schema.createRecord("Test", "", "", false);
+        schema.setFields(Arrays.asList(
+                new Schema.Field("testString", Schema.create(Schema.Type.STRING), "", null),
+                new Schema.Field("testInt", Schema.create(Schema.Type.INT), "", null),
+                new Schema.Field("testBoolean", Schema.create(Schema.Type.BOOLEAN), "", null),
+                new Schema.Field("testLong", Schema.create(Schema.Type.LONG), "", null),
+                new Schema.Field("testFloat", Schema.create(Schema.Type.FLOAT), "", null),
+                new Schema.Field("testDouble", Schema.create(Schema.Type.DOUBLE), "", null),
+                new Schema.Field("testBytesArray", Schema.create(Schema.Type.BYTES), "", null),
+                new Schema.Field("testBytesBuffer", Schema.create(Schema.Type.BYTES), "", null),
+                new Schema.Field("testNull", Schema.create(Schema.Type.NULL), "", null)
+        ));
+
+        GenericRecord record = new GenericData.Record(schema);
+        record.put("testString", "string");
+        record.put("testInt", 123);
+        record.put("testBoolean", true);
+        record.put("testLong", 123L);
+        record.put("testFloat", 123.45f);
+        record.put("testDouble", 123.45);
+        record.put("testBytesArray", new byte[] {1, 2, 3});
+        record.put("testBytesBuffer", ByteBuffer.wrap(new byte[] {4, 5, 6}));
+        record.put("testNull", null);
+
+        AvroWrapper wrapper = new AvroWrapper();
+
+        Map<String, Object> result = wrapper.wrap(record);
+
+        assertEquals("string", result.get("testString"));
+        assertEquals(123, result.get("testInt"));
+        assertEquals(true, result.get("testBoolean"));
+        assertEquals(123L, result.get("testLong"));
+        assertEquals(123.45f, result.get("testFloat"));
+        assertEquals(123.45, result.get("testDouble"));
+        assertEquals(ByteBuffer.wrap(new byte[] {1, 2, 3}), result.get("testBytesArray"));
+        assertEquals(ByteBuffer.wrap(new byte[] {4, 5, 6}), result.get("testBytesBuffer"));
+        assertNull(result.get("testNull"));
+    }
+
+    public void testWrapNestedRecord() {
+        Schema nestedSchema = Schema.createRecord("Nested", "", "", false);
+        nestedSchema.setFields(List.of(new Schema.Field("nestedField", Schema.create(Schema.Type.STRING), "", null)));
+        GenericRecord nestedRecord = new GenericData.Record(nestedSchema);
+        nestedRecord.put("nestedField", "nestedValue");
+
+        Schema schema = Schema.createRecord("Test", "", "", false);
+        schema.setFields(List.of(new Schema.Field("nested", nestedSchema, "", null)));
+        GenericRecord record = new GenericData.Record(schema);
+        record.put("nested", nestedRecord);
+        AvroWrapper wrapper = new AvroWrapper();
+
+        Map<String, Object> result = wrapper.wrap(record);
+
+        assertTrue(result.get("nested") instanceof Map);
+        assertEquals("nestedValue", ((Map) result.get("nested")).get("nestedField"));
+    }
+
+    public void testWrapArray() {
+        Schema arraySchema = Schema.createArray(Schema.create(Schema.Type.STRING));
+        GenericData.Array<String> array = new GenericData.Array<>(arraySchema, Arrays.asList("element1", "element2"));
+
+        Schema schema = Schema.createRecord("Test", "", "", false);
+        schema.setFields(List.of(new Schema.Field("array", arraySchema, "", null)));
+        GenericRecord record = new GenericData.Record(schema);
+        record.put("array", array);
+        AvroWrapper wrapper = new AvroWrapper();
+
+        Map<String, Object> result = wrapper.wrap(record);
+
+        assertTrue(result.get("array") instanceof List);
+        assertEquals("element1", ((List) result.get("array")).get(0));
+        assertEquals("element2", ((List) result.get("array")).get(1));
+    }
+
+    public void testWrapUnion() {
+        Schema unionSchema = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL)));
+        Schema schema = Schema.createRecord("Test", "", "", false);
+        schema.setFields(List.of(new Schema.Field("union", unionSchema, "", null)));
+        GenericRecord record = new GenericData.Record(schema);
+        record.put("union", "string");
+        AvroWrapper wrapper = new AvroWrapper();
+
+        Map<String, Object> result = wrapper.wrap(record);
+
+        assertEquals("string", result.get("union"));
+    }
+
+    public void testWrapUnionWithString() {
+        List<Schema> unionTypes = Arrays.asList(Schema.create(Schema.Type.INT), Schema.create(Schema.Type.STRING));
+        Schema unionSchema = Schema.createUnion(unionTypes);
+        Schema recordSchema = Schema.createRecord("TestRecord", "", "", false);
+        recordSchema.setFields(Collections.singletonList(new Schema.Field("testUnion", unionSchema, "", null)));
+
+        GenericRecord record = new GenericData.Record(recordSchema);
+        record.put("testUnion", "a string");
+
+        AvroWrapper wrapper = new AvroWrapper();
+        Map<String, Object> result = wrapper.wrap(record);
+
+        assertTrue(result.get("testUnion") instanceof String);
+        assertEquals("a string", result.get("testUnion"));
+    }
+
+    public void testWrapEnum() {
+        Schema enumSchema = Schema.createEnum("TestEnum", "", "", Arrays.asList("A", "B", "C"));
+        GenericData.EnumSymbol enumSymbol = new GenericData.EnumSymbol(enumSchema, "B");
+        Schema recordSchema = Schema.createRecord("TestRecord", "", "", false);
+        recordSchema.setFields(Collections.singletonList(new Schema.Field("testEnum", enumSchema, "", null)));
+
+        GenericRecord record = new GenericData.Record(recordSchema);
+        record.put("testEnum", enumSymbol);
+
+        AvroWrapper wrapper = new AvroWrapper();
+        Map<String, Object> result = wrapper.wrap(record);
+
+        assertEquals("B", result.get("testEnum"));
+    }
+
+    public void testWrapFixed() {
+        Schema fixedSchema = Schema.createFixed("TestFixed", "", "", 4);
+        GenericData.Fixed fixed = new GenericData.Fixed(fixedSchema, new byte[] {1, 2, 3, 4});
+        Schema recordSchema = Schema.createRecord("TestRecord", "", "", false);
+        recordSchema.setFields(Collections.singletonList(new Schema.Field("testFixed", fixedSchema, "", null)));
+
+        GenericRecord record = new GenericData.Record(recordSchema);
+        record.put("testFixed", fixed);
+
+        AvroWrapper wrapper = new AvroWrapper();
+        Map<String, Object> result = wrapper.wrap(record);
+
+        assertEquals(ByteBuffer.wrap(new byte[] {1, 2, 3, 4}), result.get("testFixed"));
+    }
+
+    public void testWrapMap() {
+        Schema mapSchema = Schema.createMap(Schema.create(Schema.Type.STRING));
+        Schema recordSchema = Schema.createRecord("TestRecord", "", "", false);
+        recordSchema.setFields(Collections.singletonList(new Schema.Field("testMap", mapSchema, "", null)));
+
+        GenericRecord record = new GenericData.Record(recordSchema);
+        record.put("testMap", new HashMap<String, Object>() {{
+            put("key1", "value1");
+            put("key2", "value2");
+        }});
+
+        AvroWrapper wrapper = new AvroWrapper();
+        Map<String, Object> result = wrapper.wrap(record);
+
+        assertTrue(result.get("testMap") instanceof Map);
+        Map<String, Object> resultMap = (Map<String, Object>) result.get("testMap");
+        assertEquals("value1", resultMap.get("key1"));
+        assertEquals("value2", resultMap.get("key2"));
+    }
+
+    public void testListOfRecords() {
+        Schema subRecordSchema = Schema.createRecord("SubRecord", "", "test", false);
+        subRecordSchema.setFields(List.of(new Schema.Field("subField", Schema.create(Schema.Type.INT), "", null)));
+
+        Schema arraySchema = Schema.createArray(subRecordSchema);
+        Schema mainRecordSchema = Schema.createRecord("MainRecord", "", "test", false);
+        mainRecordSchema.setFields(List.of(new Schema.Field("mainField", arraySchema, "", null)));
+
+        GenericRecord subRecord1 = new GenericRecordBuilder(subRecordSchema).set("subField", 1).build();
+        GenericRecord subRecord2 = new GenericRecordBuilder(subRecordSchema).set("subField", 2).build();
+        GenericData.Array<GenericRecord> array = new GenericData.Array<>(mainRecordSchema.getField("mainField").schema(), Arrays.asList(subRecord1, subRecord2));
+
+        GenericRecord mainRecord = new GenericRecordBuilder(mainRecordSchema).set("mainField", array).build();
+
+        AvroWrapper avroWrapper = new AvroWrapper();
+        Map<String, Object> wrapped = avroWrapper.wrap(mainRecord);
+
+        assertTrue(wrapped.get("mainField") instanceof List);
+        List<?> list = (List<?>) wrapped.get("mainField");
+
+        assertEquals(2, list.size());
+
+        assertTrue(list.get(0) instanceof Map);
+        Map<String, Object> subRecord1Map = (Map<String, Object>) list.get(0);
+        assertEquals(1, subRecord1Map.get("subField"));
+
+        assertTrue(list.get(1) instanceof Map);
+        Map<String, Object> subRecord2Map = (Map<String, Object>) list.get(1);
+        assertEquals(2, subRecord2Map.get("subField"));
+    }
+}


### PR DESCRIPTION
This commit adds a new functionality to the twister-avro module: the ability to wrap Avro IndexedRecords in a Map representation for easier data manipulation. To accomplish this, we introduce a new class `AvroWrapper`.

The `AvroWrapper` class provides the method `wrap(IndexedRecord record)` that returns a Map view of the given Avro IndexedRecord. The map's keys are the field names in the IndexedRecord, and the values are the field values, coerced to appropriate Java types using the internal `coerceType(Schema schema, Object value)` method. This method handles Avro primitives and complex types like records, arrays, and maps.

Key changes in this commit:

- **README.md**: Documented the new `AvroWrapper` class and updated the feature list.

- **AvroWrapper.java**: Implemented the new `AvroWrapper` class and its methods, including private helper classes `Facade`, `FacadeList`, and `FacadeMap`.

- **AvroWrapperTest.java**: Introduced unit tests to verify the behavior of the `AvroWrapper` class.

This enhancement allows for better manipulation of Avro data, particularly in cases where users want to operate on the data in a map-like manner rather than working with Avro's specific data structures. It is important to note that while this provides a Map view of an IndexedRecord, changes to the map will not reflect back onto the original record.