### PR TITLE
Configure Maven to Publish to Sonatype's Maven Central Repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,99 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>
+    <name>Twister</name>
+    <description>A handy tool that converts Avro and Protobuf data to and from Java POJOs</description>
+    <url>http://twister.dev</url>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>criccomini</id>
+            <name>Chris Riccomini</name>
+            <email>criccomini@apache.org</email>
+        </developer>
+    </developers>
+    <scm>
+        <connection>scm:git:git://github.com/criccomini/twister</connection>
+        <developerConnection>scm:git:ssh://github.com:criccomini/twister.git</developerConnection>
+        <url>http://github.com/criccomini/twister/tree/main</url>
+    </scm>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
This commit updates the `pom.xml` file to publish artifacts to the Sonatype's Maven Central Repository.

Key Changes:
- Added metadata including project name, description, URL, licenses, and developer information.
- Added SCM connection details.
- Added distributionManagement section for snapshotRepository and repository pointing to Sonatype's OSSRH.
- Added nexus-staging-maven-plugin for interaction with Nexus repositories.
- Added maven-source-plugin to attach source code as an additional artifact.
- Upgraded maven-javadoc-plugin to version 3.5.0 and added configuration to attach Javadocs as an additional artifact.
- Added maven-gpg-plugin to sign the artifacts during the verify phase.

With these changes, artifacts will be published to Maven Central Repository upon successful build and verification.