### PR TITLE
Remove SpotBugs Plugin Configuration from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,26 +126,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.7.3.4</version>
-                <configuration>
-                    <effort>Max</effort>
-                    <threshold>Low</threshold>
-                    <failOnError>true</failOnError>
-                    <xmlOutput>true</xmlOutput>
-                    <xmlOutputDirectory>${project.build.directory}/spotbugs</xmlOutputDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <dependencyManagement>


### PR DESCRIPTION
This commit removes the SpotBugs plugin configuration from the project's `pom.xml`. The changes are:

- The SpotBugs plugin configuration, including the execution goal at the 'verify' phase, has been removed.

Please note that SpotBugs was providing static analysis. We should consider an alternative strategy for maintaining code quality.