### PR TITLE
Add support for new Avro logical types and extend AvroSchemaInferrer

### DIFF
--- a/twister-avro/src/main/java/dev/twister/avro/AvroReader.java
+++ b/twister-avro/src/main/java/dev/twister/avro/AvroReader.java
@@ -12,7 +12,9 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -232,6 +234,13 @@ public class AvroReader {
         }, "timestamp-micros", (decoder, schema) -> {
             long microsSinceEpoch = decoder.readLong();
             return Instant.ofEpochSecond(microsSinceEpoch / 1_000_000, (microsSinceEpoch % 1_000_000) * 1_000);
+        }, "local-timestamp-millis", (decoder, schema) -> {
+            long millisSinceEpoch = decoder.readLong();
+            return LocalDateTime.ofInstant(Instant.ofEpochMilli(millisSinceEpoch), ZoneOffset.UTC);
+        }, "local-timestamp-micros", (decoder, schema) -> {
+            long microsSinceEpoch = decoder.readLong();
+            return LocalDateTime.ofInstant(Instant.ofEpochSecond(microsSinceEpoch / 1_000_000,
+                    (microsSinceEpoch % 1_000_000) * 1_000), ZoneOffset.UTC);
         });
     }
 }

--- a/twister-avro/src/test/java/dev/twister/avro/AvroReaderTest.java
+++ b/twister-avro/src/test/java/dev/twister/avro/AvroReaderTest.java
@@ -11,9 +11,7 @@ import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.*;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -263,6 +261,48 @@ public class AvroReaderTest extends TestCase {
         Map<String, Object> resultMap = new AvroReader().read(byteBuffer, schema);
 
         assertEquals(Instant.ofEpochSecond(timestampMicros / 1_000_000, (timestampMicros % 1_000_000) * 1_000), resultMap.get("timestampMicrosField"));
+    }
+
+    public void testLocalTimestampMillisLogicalType() throws Exception {
+        String schemaJson = "{\n" +
+                "  \"type\": \"record\",\n" +
+                "  \"name\": \"TestRecord\",\n" +
+                "  \"fields\": [\n" +
+                "    {\"name\": \"localTimestampMillisField\", \"type\": {\"type\":\"long\",\"logicalType\":\"local-timestamp-millis\"}}\n" +
+                "  ]\n" +
+                "}";
+        Schema schema = new Schema.Parser().parse(schemaJson);
+
+        long localTimestampMillis = 1234567891011L; // Represents a timestamp in milliseconds since midnight.
+        GenericData.Record record = new GenericData.Record(schema);
+        record.put("localTimestampMillisField", localTimestampMillis);
+
+        ByteBuffer byteBuffer = encodeRecordToByteBuffer(record, schema);
+        Map<String, Object> resultMap = new AvroReader().read(byteBuffer, schema);
+
+        LocalDateTime expectedDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(localTimestampMillis), ZoneOffset.UTC);
+        assertEquals(expectedDateTime, resultMap.get("localTimestampMillisField"));
+    }
+
+    public void testLocalTimestampMicrosLogicalType() throws Exception {
+        String schemaJson = "{\n" +
+                "  \"type\": \"record\",\n" +
+                "  \"name\": \"TestRecord\",\n" +
+                "  \"fields\": [\n" +
+                "    {\"name\": \"localTimestampMicrosField\", \"type\": {\"type\":\"long\",\"logicalType\":\"local-timestamp-micros\"}}\n" +
+                "  ]\n" +
+                "}";
+        Schema schema = new Schema.Parser().parse(schemaJson);
+
+        long localTimestampMicros = 12345678910111213L; // Represents a timestamp in microseconds since midnight.
+        GenericData.Record record = new GenericData.Record(schema);
+        record.put("localTimestampMicrosField", localTimestampMicros);
+
+        ByteBuffer byteBuffer = encodeRecordToByteBuffer(record, schema);
+        Map<String, Object> resultMap = new AvroReader().read(byteBuffer, schema);
+
+        LocalDateTime expectedDateTime = LocalDateTime.ofInstant(Instant.ofEpochSecond(localTimestampMicros / 1_000_000, (localTimestampMicros % 1_000_000) * 1_000), ZoneOffset.UTC);
+        assertEquals(expectedDateTime, resultMap.get("localTimestampMicrosField"));
     }
 
     private ByteBuffer encodeRecordToByteBuffer(GenericData.Record record, Schema schema) throws Exception {

--- a/twister-avro/src/test/java/dev/twister/avro/AvroSchemaInferrerTest.java
+++ b/twister-avro/src/test/java/dev/twister/avro/AvroSchemaInferrerTest.java
@@ -4,6 +4,8 @@ import junit.framework.TestCase;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 
+import java.math.BigDecimal;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -64,7 +66,7 @@ public class AvroSchemaInferrerTest extends TestCase {
         map.put("field3", 45.67);
 
         // Create an AvroSchemaInferrer with mapAsRecord = false
-        AvroSchemaInferrer inferrer = new AvroSchemaInferrer(false);
+        AvroSchemaInferrer inferrer = new AvroSchemaInferrer(false, ChronoUnit.MILLIS);
 
         // Infer the Avro schema for the map
         Schema schema = inferrer.infer(map, "TestRecord");
@@ -72,5 +74,16 @@ public class AvroSchemaInferrerTest extends TestCase {
         // Check that the resulting schema is a map schema with a union value type
         assertEquals(Schema.Type.MAP, schema.getType());
         assertEquals(Schema.Type.UNION, schema.getValueType().getType());
+    }
+
+    public void testBigDecimal() {
+        Map<String, Object> map = new HashMap<>();
+        BigDecimal decimalValue = new BigDecimal("123.456");
+        map.put("decimalField", decimalValue);
+
+        Schema schema = new AvroSchemaInferrer().infer(map, "TestDecimal");
+        String expectedSchema = String.format("{\"type\":\"record\",\"name\":\"TestDecimal\",\"fields\":[{\"name\":\"decimalField\",\"type\":[\"null\",{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":%d,\"scale\":%d}]}]}", decimalValue.precision(), decimalValue.scale());
+
+        assertEquals(expectedSchema, schema.toString());
     }
 }


### PR DESCRIPTION
This commit expands support in `AvroReader` and `AvroSchemaInferrer` for additional Avro logical types: 'local-timestamp-millis', 'local-timestamp-micros', 'decimal', and 'uuid'.

In `AvroReader`, the ability to read 'local-timestamp-millis' and 'local-timestamp-micros' has been added. These types allow encoding of `LocalDateTime` objects as long values.

The `AvroSchemaInferrer` class has been expanded to infer schemas for `BigDecimal`, `UUID`, `LocalDate`, `LocalTime`, `Instant`, and `LocalDateTime` types. This is crucial when dealing with a range of Java objects that need to be serialized using Avro.

Additionally, a `timePrecision` parameter has been added to `AvroSchemaInferrer`, allowing users to specify whether Avro logical types based on time should be precise to the millisecond or microsecond.

Corresponding tests have been added to validate these new functionalities.