### PR TITLE
Update AvroWrapper to expose logical type readers and converters

### DIFF
--- a/twister-avro/src/main/java/dev/twister/avro/AvroReader.java
+++ b/twister-avro/src/main/java/dev/twister/avro/AvroReader.java
@@ -42,7 +42,7 @@ public class AvroReader {
      *   <li>timestamp-micros</li>
      * </ul>
      */
-    private static final Map<String, LogicalTypeReader> DEFAULT_LOGICAL_TYPE_READERS;
+    public static final Map<String, LogicalTypeReader> DEFAULT_LOGICAL_TYPE_READERS;
 
     /**
      * A {@link Map} of {@link LogicalTypeReader}s used to interpret Avro logical types.

--- a/twister-avro/src/main/java/dev/twister/avro/AvroSchemaInferrer.java
+++ b/twister-avro/src/main/java/dev/twister/avro/AvroSchemaInferrer.java
@@ -10,13 +10,13 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A utility class to infer Avro schema from Java objects.
@@ -30,26 +30,26 @@ public class AvroSchemaInferrer {
     private final boolean mapAsRecord;
 
     /**
-     * A ChronoUnit to determine the precision of time-based Avro logical types.
+     * A TimeUnit to determine the precision of time-based Avro logical types.
      * It must be either MILLIS or MICROS.
      */
-    private final ChronoUnit timePrecision;
+    private final TimeUnit timePrecision;
 
     /**
      * Creates an AvroSchemaInferrer with the default behavior of treating maps as records.
      */
     public AvroSchemaInferrer() {
-        this(true, ChronoUnit.MILLIS);
+        this(true, TimeUnit.MILLISECONDS);
     }
 
     /**
      * Creates an AvroSchemaInferrer.
      *
      * @param mapAsRecord A flag to indicate whether maps should be treated as records.
-     * @param timePrecision A ChronoUnit to determine the precision of time-based Avro logical types.
+     * @param timePrecision A TimeUnit to determine the precision of time-based Avro logical types.
      */
-    public AvroSchemaInferrer(boolean mapAsRecord, ChronoUnit timePrecision) {
-        if (timePrecision != ChronoUnit.MILLIS && timePrecision != ChronoUnit.MICROS) {
+    public AvroSchemaInferrer(boolean mapAsRecord, TimeUnit timePrecision) {
+        if (timePrecision != TimeUnit.MILLISECONDS && timePrecision != TimeUnit.MICROSECONDS) {
             throw new IllegalArgumentException("Unsupported time precision: " + timePrecision);
         }
         this.mapAsRecord = mapAsRecord;
@@ -125,19 +125,19 @@ public class AvroSchemaInferrer {
         } else if (value instanceof LocalDate) {
             schema = LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT));
         } else if (value instanceof LocalTime) {
-            if (timePrecision == ChronoUnit.MILLIS) {
+            if (timePrecision == TimeUnit.MILLISECONDS) {
                 schema = LogicalTypes.timeMillis().addToSchema(Schema.create(Schema.Type.INT));
             } else {
                 schema = LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG));
             }
         } else if (value instanceof Instant) {
-            if (timePrecision == ChronoUnit.MILLIS) {
+            if (timePrecision == TimeUnit.MILLISECONDS) {
                 schema = LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG));
             } else {
                 schema = LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
             }
         } else if (value instanceof LocalDateTime) {
-            if (timePrecision == ChronoUnit.MILLIS) {
+            if (timePrecision == TimeUnit.MILLISECONDS) {
                 schema = LogicalTypes.localTimestampMillis().addToSchema(Schema.create(Schema.Type.LONG));
             } else {
                 schema = LogicalTypes.localTimestampMicros().addToSchema(Schema.create(Schema.Type.LONG));

--- a/twister-avro/src/main/java/dev/twister/avro/AvroWrapper.java
+++ b/twister-avro/src/main/java/dev/twister/avro/AvroWrapper.java
@@ -1,23 +1,47 @@
 package dev.twister.avro;
 
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.IndexedRecord;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.AbstractList;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class provides functionality to wrap Avro IndexedRecord objects
  * into a Map representation for easier data manipulation.
  */
 public class AvroWrapper {
+
+    private static final Map<String, LogicalTypeConverter> DEFAULT_LOGICAL_TYPE_CONVERTERS;
+
+    private final Map<String, LogicalTypeConverter> logicalTypeConverters;
+
+    public AvroWrapper() {
+        this(DEFAULT_LOGICAL_TYPE_CONVERTERS);
+    }
+
+    public AvroWrapper(Map<String, LogicalTypeConverter> logicalTypeConverters) {
+        this.logicalTypeConverters = logicalTypeConverters;
+    }
 
     /**
      * Wraps the given IndexedRecord into a Map.
@@ -39,6 +63,13 @@ public class AvroWrapper {
      * @return the coerced value, or throws IllegalArgumentException if the Avro type is unsupported
      */
     private Object coerceType(Schema schema, Object value) {
+        if (schema.getLogicalType() != null) {
+            LogicalTypeConverter converter = logicalTypeConverters.get(schema.getLogicalType().getName());
+            if (converter != null) {
+                return converter.convert(value);
+            }
+        }
+
         switch (schema.getType()) {
             case RECORD:
                 return new Facade((IndexedRecord) value);
@@ -207,4 +238,39 @@ public class AvroWrapper {
             };
         }
     }
+
+    public interface LogicalTypeConverter {
+        Object convert(Object value);
+    }
+
+    static {
+        DEFAULT_LOGICAL_TYPE_CONVERTERS = Map.of(
+                "decimal", value -> {
+                    GenericData.Fixed fixed = (GenericData.Fixed) value;
+                    byte[] bytes = fixed.bytes();
+                    int scale = ((LogicalTypes.Decimal) fixed.getSchema().getLogicalType()).getScale();
+                    byte[] valueBytes = Arrays.copyOfRange(bytes, 0, bytes.length);
+                    return new BigDecimal(new BigInteger(valueBytes), scale);
+                },
+                "uuid", value -> UUID.fromString((String) value),
+                "date", value -> LocalDate.ofEpochDay((int) value),
+                "time-millis", value -> LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos((int) value)),
+                "time-micros", value -> LocalTime.ofNanoOfDay(TimeUnit.MICROSECONDS.toNanos((long) value)),
+                "timestamp-millis", value -> Instant.ofEpochMilli((long) value),
+                "timestamp-micros", value -> Instant.ofEpochSecond(0, (long) value * 1000),
+                "local-timestamp-millis", value -> {
+                    long longValue = (long) value;
+                    long seconds = longValue / 1000;
+                    int nanos = (int) (longValue % 1000) * 1000000;
+                    return LocalDateTime.ofEpochSecond(seconds, nanos, ZoneOffset.UTC);
+                },
+                "local-timestamp-micros", value -> {
+                    long longValue = (long) value;
+                    long seconds = longValue / 1000000;
+                    int nanos = (int) (longValue % 1000000) * 1000;
+                    return LocalDateTime.ofEpochSecond(seconds, nanos, ZoneOffset.UTC);
+                }
+        );
+    }
+
 }

--- a/twister-avro/src/test/java/dev/twister/avro/AvroSchemaInferrerTest.java
+++ b/twister-avro/src/test/java/dev/twister/avro/AvroSchemaInferrerTest.java
@@ -5,10 +5,10 @@ import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 
 import java.math.BigDecimal;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class AvroSchemaInferrerTest extends TestCase {
     public void testSchemaInferrer() {
@@ -66,7 +66,7 @@ public class AvroSchemaInferrerTest extends TestCase {
         map.put("field3", 45.67);
 
         // Create an AvroSchemaInferrer with mapAsRecord = false
-        AvroSchemaInferrer inferrer = new AvroSchemaInferrer(false, ChronoUnit.MILLIS);
+        AvroSchemaInferrer inferrer = new AvroSchemaInferrer(false, TimeUnit.MILLISECONDS);
 
         // Infer the Avro schema for the map
         Schema schema = inferrer.infer(map, "TestRecord");


### PR DESCRIPTION
Update AvroWrapper to expose the logical type readers and converters as public fields, allowing external access and customization. The changes are as follows:

In AvroReader:
- Changed the accessibility of the DEFAULT_LOGICAL_TYPE_READERS map from private to public.

In AvroWrapper:
- Added the DEFAULT_LOGICAL_TYPE_CONVERTERS map as a public field.
- Added the logicalTypeConverters field to store the logical type converters.
- Updated the constructors to accept the logical type converters map.
- Added the LogicalTypeConverter interface to define the conversion behavior.
- Implemented default logical type converters for various Avro logical types.
- Modified the coerceType method to utilize the logical type converters for typed conversions.
- Updated the wrap method to use the logical type converters for wrapping logical type values.

These changes provide more flexibility and extensibility when working with Avro logical types in the AvroReader and AvroWrapper classes.