### PR TITLE
Refactor AvroWrapper and Enhance AvroWriter with LogicalTypeWriters

### DIFF
--- a/twister-avro/src/main/java/dev/twister/avro/AvroWrapper.java
+++ b/twister-avro/src/main/java/dev/twister/avro/AvroWrapper.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class AvroWrapper {
 
-    private static final Map<String, LogicalTypeConverter> DEFAULT_LOGICAL_TYPE_CONVERTERS;
+    public static final Map<String, LogicalTypeConverter> DEFAULT_LOGICAL_TYPE_CONVERTERS;
 
     private final Map<String, LogicalTypeConverter> logicalTypeConverters;
 


### PR DESCRIPTION
This commit refactors AvroWrapper and enhances AvroWriter.

Changes:
1. The `DEFAULT_LOGICAL_TYPE_CONVERTERS` in `AvroWrapper` is now public, enabling broader usage.
2. `AvroWriter` now includes a collection of LogicalTypeWriters for handling specific Avro logical types.
3. Added two constructors to `AvroWriter`: a default using built-in logical type writers, and another accepting a custom map of logical type writers.
4. Incorporated `writeObject` and `getExpectedClass` methods into `AvroWriter` to facilitate writing Avro data based on logical types.
5. Several `LogicalTypeWriter` implementations have been included to handle specific Avro logical types.

Accompanying tests for these enhancements have been added.